### PR TITLE
[라우터] 피그마 명세에 따른 페이지 생성 및 라우팅처리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components'
 import GlobalStyle from './styles/GlobalStyle'
+import AppRouter from './routes/router'
+
 const App = () => {
 	return (
 		<>
 			<GlobalStyle />
 			<Container>
-				<div className="App">
-					<h2>Hello Time Divider</h2>
-				</div>
+				<AppRouter />
 			</Container>
 		</>
 	)

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,11 @@ const App = () => {
 export default App
 
 const Container = styled.div`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	box-sizing: border-box;
+	align-items: center;
 	width: 100%;
 	max-width: 420px;
 	height: 100vh;

--- a/src/pages/addToDoTimeDivider.jsx
+++ b/src/pages/addToDoTimeDivider.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const addToDoTimeDivider = () => {
+	return (
+		<>
+			<h2>addToDoTimeDivider</h2>
+		</>
+	)
+}
+
+export default addToDoTimeDivider

--- a/src/pages/addToDoTimeDivider.jsx
+++ b/src/pages/addToDoTimeDivider.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-export const addToDoTimeDivider = () => {
+export const AddToDoTimeDivider = () => {
 	return (
 		<>
-			<h2>addToDoTimeDivider</h2>
+			<h2>AddToDoTimeDivider</h2>
 		</>
 	)
 }
 
-export default addToDoTimeDivider
+export default AddToDoTimeDivider

--- a/src/pages/createTime.jsx
+++ b/src/pages/createTime.jsx
@@ -1,13 +1,48 @@
-import React from 'react'
+import React, { useState } from 'react'
+
 import { Link } from 'react-router-dom'
 
-const createTime = () => {
+import styled from 'styled-components'
+import NavBar from '../components/NavBar'
+import Text from '../components/Text'
+import Button from '../components/Button'
+import Input from '../components/Input'
+
+const CreateTime = () => {
+	const [task, setTask] = useState('')
+
 	return (
 		<>
-			<h2>오늘의 시간</h2>
-			<Link to="/createTodo">다음으로</Link>
+			<NavBar>오늘의 시간</NavBar>
+
+			<SubTitleArea>
+				<Text style={{ fontSize: '1rem' }}>오늘 사용할 수 있는 시간은 얼마인가요?</Text>
+			</SubTitleArea>
+
+			<Input type="text" value={task} onChange={e => setTask(e.target.value)}></Input>
+
+			<ButtonArea>
+				<Link to="/createTodo">
+					<Button disabled={true}>입력해주세요</Button>
+				</Link>
+			</ButtonArea>
 		</>
 	)
 }
 
-export default createTime
+export default CreateTime
+
+const SubTitleArea = styled.div`
+	height: 30vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+`
+
+const ButtonArea = styled.div`
+	position: absolute;
+	margin: 2rem 2rem;
+	width: 100%;
+	bottom: 1rem;
+`

--- a/src/pages/createTime.jsx
+++ b/src/pages/createTime.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+const createTime = () => {
+	return (
+		<>
+			<h2>오늘의 시간</h2>
+			<Link to="/createTodo">다음으로</Link>
+		</>
+	)
+}
+
+export default createTime

--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-export const createTimeDivider = () => {
+export const CreateTimeDivider = () => {
 	return (
 		<>
 			<h2>시간을 분배해요</h2>
@@ -10,4 +10,4 @@ export const createTimeDivider = () => {
 	)
 }
 
-export default createTimeDivider
+export default CreateTimeDivider

--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+export const createTimeDivider = () => {
+	return (
+		<>
+			<h2>시간을 분배해요</h2>
+			<Link to="/updateDivider">다음으로</Link>
+		</>
+	)
+}
+
+export default createTimeDivider

--- a/src/pages/createTodo.jsx
+++ b/src/pages/createTodo.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+export const createTodo = () => {
+	return (
+		<>
+			<h2>해야 할 일을 적어요</h2>
+			<Link to="/createTimeDivider">다음으로</Link>
+		</>
+	)
+}
+
+export default createTodo

--- a/src/pages/createTodo.jsx
+++ b/src/pages/createTodo.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-export const createTodo = () => {
+export const CreateTodo = () => {
 	return (
 		<>
 			<h2>해야 할 일을 적어요</h2>
@@ -10,4 +10,4 @@ export const createTodo = () => {
 	)
 }
 
-export default createTodo
+export default CreateTodo

--- a/src/pages/doneToDoTimeDivider.jsx
+++ b/src/pages/doneToDoTimeDivider.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-const doneToDoTimeDivider = () => {
+const DoneToDoTimeDivider = () => {
 	return (
 		<>
-			<h2>doneToDoTimeDivider</h2>
+			<h2>DoneToDoTimeDivider</h2>
 		</>
 	)
 }
 
-export default doneToDoTimeDivider
+export default DoneToDoTimeDivider

--- a/src/pages/doneToDoTimeDivider.jsx
+++ b/src/pages/doneToDoTimeDivider.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const doneToDoTimeDivider = () => {
+	return (
+		<>
+			<h2>doneToDoTimeDivider</h2>
+		</>
+	)
+}
+
+export default doneToDoTimeDivider

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,14 +1,51 @@
 import React from 'react'
+
 import { Link } from 'react-router-dom'
 
-const home = () => {
+import styled from 'styled-components'
+import Button from '../components/Button'
+import Text from '../components/Text'
+import { IoIosHourglass } from 'react-icons/io'
+
+const Home = () => {
 	return (
 		<>
-			<h2>Home</h2>
-			<p>첫 화면 - 프로젝트 명</p>
-			<Link to="/createTime">시작하기</Link>
+			<Title>
+				<Text style={{ fontSize: '2rem' }}>일 모래시계</Text>
+			</Title>
+
+			<HourGlass>
+				<IoIosHourglass></IoIosHourglass>
+			</HourGlass>
+
+			<Text style={{ fontSize: '2rem' }}>시간을 관리해보세요!</Text>
+
+			<ButtonArea>
+				<Link to="/createTime">
+					<Button>시작하기</Button>
+				</Link>
+			</ButtonArea>
 		</>
 	)
 }
 
-export default home
+export default Home
+
+const Title = styled.h2`
+	padding: 2rem;
+`
+
+const HourGlass = styled.span`
+	height: 50vh;
+	font-size: 30vh;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+`
+
+const ButtonArea = styled.div`
+	position: absolute;
+	margin: 2rem 2rem;
+	width: 100%;
+	bottom: 1rem;
+`

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+const home = () => {
+	return (
+		<>
+			<h2>Home</h2>
+			<p>첫 화면 - 프로젝트 명</p>
+			<Link to="/createTime">시작하기</Link>
+		</>
+	)
+}
+
+export default home

--- a/src/pages/notFound.jsx
+++ b/src/pages/notFound.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+const NotFound = () => {
+	return (
+		<>
+			<h2> Not Found </h2>
+			<Link to="home">HOME</Link>
+		</>
+	)
+}
+
+export default NotFound

--- a/src/pages/updateTimeDivider.jsx
+++ b/src/pages/updateTimeDivider.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-const updateTimeDivider = () => {
+const UpdateTimeDivider = () => {
 	return (
 		<>
 			<h2>모래시계 편집하기</h2>
@@ -11,4 +11,4 @@ const updateTimeDivider = () => {
 	)
 }
 
-export default updateTimeDivider
+export default UpdateTimeDivider

--- a/src/pages/updateTimeDivider.jsx
+++ b/src/pages/updateTimeDivider.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+const updateTimeDivider = () => {
+	return (
+		<>
+			<h2>모래시계 편집하기</h2>
+			<Link to="/doneTodo">완료하기</Link>
+			<Link to="/addTodo">추가하기</Link>
+		</>
+	)
+}
+
+export default updateTimeDivider

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -1,0 +1,15 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import routes from './routes'
+
+const AppRouter = () => {
+	return (
+		<BrowserRouter>
+			<Routes>
+				{routes.map(route => (
+					<Route path={route.path} key={route.path} title={route.title} element={<route.view />} />
+				))}
+			</Routes>
+		</BrowserRouter>
+	)
+}
+export default AppRouter

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -1,0 +1,53 @@
+import Home from '../pages/home'
+import CreateTime from '../pages/createTime'
+import CreateTodo from '../pages/createTodo'
+import CreateTimeDivider from '../pages/createTimeDivider'
+import UpdateTimeDivider from '../pages/updateTimeDivider'
+import DoneToDoTimeDivider from '../pages/doneToDoTimeDivider'
+import AddToDoTimeDivider from '../pages/addToDoTimeDivider'
+import NotFound from '../pages/notFound'
+
+const routes = [
+	{
+		path: 'home',
+		view: Home,
+		title: '첫 화면',
+	},
+	{
+		path: 'createTime',
+		view: CreateTime,
+		title: '오늘의 시간',
+	},
+	{
+		path: 'createTodo',
+		view: CreateTodo,
+		title: '해야 할 일을 적어요',
+	},
+	{
+		path: 'createTimeDivider',
+		view: CreateTimeDivider,
+		title: '시간을 분배해요',
+	},
+	{
+		path: 'updateDivider',
+		view: UpdateTimeDivider,
+		title: '모래시계 편집하기',
+	},
+	{
+		path: 'doneTodo',
+		view: DoneToDoTimeDivider,
+		title: '할 일 완료하기',
+	},
+	{
+		path: 'addTodo',
+		view: AddToDoTimeDivider,
+		title: '할 일 추가하기',
+	},
+	{
+		path: '*',
+		view: NotFound,
+		title: '404',
+	},
+]
+
+export default routes


### PR DESCRIPTION
## 개요
개인 페이지 작업 시작 전 필요한 라우팅 설정

## 작업 내용
피그마 명세 기준의 페이지 생성 및 기본 페이지 라우팅 설정

## 관련 이슈
1. page명 합의
2. title 메타데이터 이관  -- 현재는 페이지를 공유용 작업페이지 명시용으로 사용
3. 레이아웃 네비게이션 세팅 필요
4. 네비게이션 가드 및 후속 작업 필요

## 참고 자료

피그마 명세 - https://www.figma.com/file/55rLirP3Lt9mifvgfOLi6n/Time?node-id=0%3A1