### PR TITLE
[컴포넌트] 공통 컴포넌트 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",
+        "styled-reset": "^4.4.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -28514,6 +28515,21 @@
         "react-is": ">= 16.8.0"
       }
     },
+    "node_modules/styled-reset": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.1.tgz",
+      "integrity": "sha512-7j99JIwzotNQmoS8MQJu8OTBDE48gaMEr6SYvuH8xfL0K/a5vNHSRaccTfAiGBs9D3mjLDPxg5iLh3HqFvefPQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/zacanger"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -52590,6 +52606,12 @@
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
       }
+    },
+    "styled-reset": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.1.tgz",
+      "integrity": "sha512-7j99JIwzotNQmoS8MQJu8OTBDE48gaMEr6SYvuH8xfL0K/a5vNHSRaccTfAiGBs9D3mjLDPxg5iLh3HqFvefPQ==",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 const StyledButton = styled.button`
@@ -52,6 +53,12 @@ const StyledButton = styled.button`
 
 const Button = ({ rect = false, size, inline = false, ...props }) => {
 	return <StyledButton {...props} inline={inline} size={size} rect={rect} />
+}
+
+Text.propTypes = {
+	rect: PropTypes.bool,
+	size: PropTypes.string,
+	inline: PropTypes.bool,
 }
 
 export default Button

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -27,9 +27,9 @@ const StyledButton = styled.button`
 	}
 `
 
-const Button = ({ disabled = false, children = 'Button', onClick }) => {
+const Button = ({ disabled = false, children = 'Button', onClick, ...props }) => {
 	return (
-		<StyledButton disabled={disabled} onClick={onClick}>
+		<StyledButton {...props} disabled={disabled} onClick={onClick}>
 			{children}
 		</StyledButton>
 	)

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,14 +1,37 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 const StyledButton = styled.button`
-	display: block;
+	display: ${props => (props.inline ? 'inline' : 'block')};
+	${props => {
+		switch (props.size) {
+			case 'sm':
+				return css`
+					width: 3.5rem;
+					hegiht: 1.25rem;
+				`
+			case 'md':
+				return css`
+					width: 6.5rem;
+					height: 2rem;
+				`
+			case 'lg':
+				return css`
+					width: 13rem;
+					height: 2.25rem;
+				`
+			default:
+				return css`
+					width: 100%;
+					hegiht: 2rem;
+				`
+		}
+	}}
 	padding: 0.5rem 0.5rem;
-	width: 100%;
-	height: 2rem;
 	background-color: #10d0a3;
 	border: none;
 	outline: none;
-	border-radius: 1rem;
+	text-align: center;
+	border-radius: ${props => (props.rect ? '0.5rem' : '1rem')};
 	color: white;
 	box-sizing: border-box;
 	cursor: pointer;
@@ -27,12 +50,8 @@ const StyledButton = styled.button`
 	}
 `
 
-const Button = ({ disabled = false, children = 'Button', onClick, ...props }) => {
-	return (
-		<StyledButton {...props} disabled={disabled} onClick={onClick}>
-			{children}
-		</StyledButton>
-	)
+const Button = ({ rect = false, size, inline = false, ...props }) => {
+	return <StyledButton {...props} inline={inline} size={size} rect={rect} />
 }
 
 export default Button

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -10,8 +10,8 @@ const StyledInput = styled.input`
 	text-align: center;
 `
 
-const Input = () => {
-	return <StyledInput />
+const Input = ({ ...props }) => {
+	return <StyledInput {...props} />
 }
 
 export default Input

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -28,7 +28,7 @@ const NavBar = ({ children = '시간 분배', backIcon, href, ...props }) => {
 					<IoIosArrowBack />
 				</GoBackIcon>
 			)}
-			<Text size="2">{children}</Text>
+			<Text size={2}>{children}</Text>
 		</NavBarContainer>
 	)
 }

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -20,9 +20,9 @@ const GoBackIcon = styled.a`
 	cursor: pointer;
 `
 
-const NavBar = ({ children = '시간 분배', backIcon, href }) => {
+const NavBar = ({ children = '시간 분배', backIcon, href, ...props }) => {
 	return (
-		<NavBarContainer>
+		<NavBarContainer {...props}>
 			{backIcon && (
 				<GoBackIcon href={href}>
 					<IoIosArrowBack />

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { IoIosArrowBack } from 'react-icons/io'
 import Text from './Text'
@@ -20,17 +21,23 @@ const GoBackIcon = styled.a`
 	cursor: pointer;
 `
 
-const NavBar = ({ children = '시간 분배', backIcon, href, ...props }) => {
+const NavBar = ({ children = '시간 분배', backIcon, ...props }) => {
 	return (
 		<NavBarContainer {...props}>
 			{backIcon && (
-				<GoBackIcon href={href}>
+				<GoBackIcon>
 					<IoIosArrowBack />
 				</GoBackIcon>
 			)}
 			<Text size={2}>{children}</Text>
 		</NavBarContainer>
 	)
+}
+
+Text.propTypes = {
+	children: PropTypes.node,
+	backIcon: PropTypes.bool,
+	link: PropTypes.string,
 }
 
 export default NavBar

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -6,24 +6,28 @@ const NavBarContainer = styled.div`
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
+	position: relative;
 	padding: 1.25rem;
 	border-bottom: 0.05rem solid #999;
 `
 
 const GoBackIcon = styled.a`
 	font-size: 2rem;
-	position: fixed;
+	position: absolute;
 	left: 1.5rem;
-	top: 2.5rem;
+	top: 1.25rem;
 	cursor: pointer;
 `
 
-const NavBar = ({ children = '시간 분배' }) => {
+const NavBar = ({ children = '시간 분배', backIcon, href }) => {
 	return (
 		<NavBarContainer>
-			<GoBackIcon href="/">
-				<IoIosArrowBack />
-			</GoBackIcon>
+			{backIcon && (
+				<GoBackIcon href={href}>
+					<IoIosArrowBack />
+				</GoBackIcon>
+			)}
 			<Text size="2">{children}</Text>
 		</NavBarContainer>
 	)

--- a/src/components/Text.jsx
+++ b/src/components/Text.jsx
@@ -1,8 +1,10 @@
-const Text = ({ children, block, paragraph, size, strong, color, ...props }) => {
-	const Tag = block ? 'div' : paragraph ? 'p' : 'span'
+import PropTypes from 'prop-types'
+
+const Text = ({ children, block, size, strong, color, ...props }) => {
+	const Tag = block ? 'div' : 'span'
 	const fontStyle = {
 		fontWeight: strong ? 'bold' : undefined,
-		fontSize: `${size}rem`,
+		fontSize: `${typeof size === 'number' ? `${size}rem` : size}`,
 		color: color,
 	}
 
@@ -11,6 +13,13 @@ const Text = ({ children, block, paragraph, size, strong, color, ...props }) => 
 			{children}
 		</Tag>
 	)
+}
+
+Text.propTypes = {
+	children: PropTypes.node.isRequired,
+	size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	block: PropTypes.bool,
+	color: PropTypes.string,
 }
 
 export default Text

--- a/src/pages/createTime.jsx
+++ b/src/pages/createTime.jsx
@@ -13,7 +13,9 @@ const CreateTime = () => {
 
 	return (
 		<>
-			<NavBar>오늘의 시간</NavBar>
+			<NavBar backIcon href="/">
+				오늘의 시간
+			</NavBar>
 
 			<SubTitleArea>
 				<Text style={{ fontSize: '1rem' }}>오늘 사용할 수 있는 시간은 얼마인가요?</Text>

--- a/src/stories/Button.stories.jsx
+++ b/src/stories/Button.stories.jsx
@@ -4,16 +4,19 @@ export default {
 	title: 'Component/Button',
 	component: Button,
 	argTypes: {
-		children: {
-			control: { type: 'text' },
-		},
-		disabled: {
-			control: { type: 'boolean' },
-		},
-		onClick: { action: 'onClick' },
+		children: { defaultValue: 'Button', control: { type: 'text' } },
+		size: { control: { type: 'text' } },
+		disabled: { control: { type: 'boolean' } },
+		inline: { control: { type: 'boolean' } },
+		rect: { control: { type: 'boolean' } },
 	},
 }
 
 export const Default = args => {
-	return <Button {...args}>{args.children}</Button>
+	return (
+		<div>
+			<Button {...args}></Button>
+			<Button {...args}></Button>
+		</div>
+	)
 }

--- a/src/stories/NavBar.stories.jsx
+++ b/src/stories/NavBar.stories.jsx
@@ -3,8 +3,12 @@ import NavBar from '../components/NavBar'
 export default {
 	title: 'Component/NavBar',
 	component: NavBar,
+	argTypes: {
+		children: { defaultValue: 'Nav', control: { type: 'text' } },
+		backIcon: { control: { type: 'boolean' } },
+	},
 }
 
 export const Default = args => {
-	return <NavBar {...args}>{args.children}</NavBar>
+	return <NavBar {...args}></NavBar>
 }

--- a/src/stories/Text.stories.jsx
+++ b/src/stories/Text.stories.jsx
@@ -4,13 +4,10 @@ export default {
 	title: 'Component/Text',
 	component: Text,
 	argTypes: {
-		size: { control: 'string' },
+		size: { control: 'number' },
 		strong: { control: 'boolean' },
-		underline: { control: 'boolean' },
-		delete: { control: 'boolean' },
 		color: { control: 'color' },
 		block: { control: 'boolean' },
-		paragraph: { control: 'boolean' },
 	},
 }
 

--- a/src/stories/Text.stories.jsx
+++ b/src/stories/Text.stories.jsx
@@ -11,8 +11,6 @@ export default {
 		color: { control: 'color' },
 		block: { control: 'boolean' },
 		paragraph: { control: 'boolean' },
-		code: { control: 'boolean' },
-		mark: { control: 'boolean' },
 	},
 }
 


### PR DESCRIPTION
close #11

## 개요
공통 컴포넌트 오류 수정

## 작업 내용

### Navbar

CSS 설정 변경으로 NavBar가 컨테이너 밖으로 나가는 현상을 수정했습니다.

### Button

사이즈 조절 prop을추가했습니다

- `size` prop에 `'sm','md','lg'` 를 추가해 적절한 버튼 사이즈를 설정할 수 있습니다.
- 해당 사이즈 분류가 사용하기에 부적절하다면 이후 논의를 통해 변경하겠습니다.
- size를 할당하지 않으면 `width :100%`로 사용되도록 설정했습니다

display 구분 prop을 추가했습니다.

- `inline` prop을 명시하면 Button이 Inline으로 동작하도록 구현했습니다
- default는 block입니다.

rect prop을 추가했습니다.
- `rect` prop을 명시하면 직사각형 형태의 버튼이 렌더링 되도록 구현했습니다.

### Input

Input에 onChagne 입력되도록 수정했습니다.

```javascript
const Component = ({ ...props }) => {
    const <Something {...props} />
}
```
기본 props들을 할당하지 않는 실수여서 수정했습니다.

이후에 작성하는 모든 컴포넌트에는 기본 props가 할당되도록 작성해야 할 것 같습니다.

### Text
이 부분은 text 사용하실 때 style prop으로 설정하지 않고 `size={1}`의 방식으로 사용하면 해결할 수 있습니다.

기본 단위는 항상 `rem`을 사용하기로 했기 때문에 자동으로 rem 사용되도록 구현했습니다.
+ `size={'1rem'}`으로 작성하셔도 동작은 되도록 수정했습니다.

## 그 외

Navbar 컴포넌트가 Link를 받을 수 있도록 수정해야 하는데 구현 방식에 대해서 Routing 구현하신 다혜님과 논의가 필요할 것 같아서 우선은 UI만 나타내도록 유지했습니다.
