### PR TITLE
[컴포넌트] 모달 컴포넌트 구현

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useMemo } from 'react'
+import styled from 'styled-components'
+import ReactDOM from 'react-dom'
+
+const BackgroundDim = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+	background-color: rgba(0, 0, 0, 0.5);
+	z-index: 1000;
+`
+const ModalContainer = styled.div`
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	padding: 0.5rem;
+	border-radius: 0.5rem;
+	background-color: white;
+	box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.2);
+	box-sizing: border-box;
+`
+
+const Modal = ({ children, width = '20rem', height, visible = false, onClose, ...props }) => {
+	const containerStyle = useMemo(
+		() => ({
+			width,
+			height,
+		}),
+		[width, height],
+	)
+
+	const el = useMemo(() => document.createElement('div'), [])
+	useEffect(() => {
+		document.body.appendChild(el)
+		return () => {
+			document.body.removeChild(el)
+		}
+	})
+	return ReactDOM.createPortal(
+		<BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
+			<ModalContainer {...props} style={{ ...props.style, ...containerStyle }}>
+				{children}
+			</ModalContainer>
+		</BackgroundDim>,
+		el,
+	)
+}
+
+export default Modal

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -24,15 +24,22 @@ const ModalContainer = styled.div`
 	box-sizing: border-box;
 `
 
-const Modal = ({ children, width = '20rem', height, visible = false, onClose, ...props }) => {
+const CloseButton = styled.div`
+	position: fixed;
+	top: 0;
+	right: 1rem;
+	cursor: pointer;
+`
+
+const Modal = ({ children, width = 18.75, height, visible = false, onClose, ...props }) => {
 	const ref = useClickAway(() => {
 		onClose && onClose()
 	})
 
 	const containerStyle = useMemo(
 		() => ({
-			width,
-			height,
+			width: `${width}rem`,
+			height: `${height}rem`,
 		}),
 		[width, height],
 	)
@@ -49,6 +56,7 @@ const Modal = ({ children, width = '20rem', height, visible = false, onClose, ..
 	return ReactDOM.createPortal(
 		<BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
 			<ModalContainer ref={ref} {...props} style={{ ...props.style, ...containerStyle }}>
+				<CloseButton onClick={onClose}>x</CloseButton>
 				{children}
 			</ModalContainer>
 		</BackgroundDim>,

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 import ReactDOM from 'react-dom'
+import useClickAway from '../hooks/useClickAway'
 
 const BackgroundDim = styled.div`
 	position: fixed;
@@ -24,6 +25,10 @@ const ModalContainer = styled.div`
 `
 
 const Modal = ({ children, width = '20rem', height, visible = false, onClose, ...props }) => {
+	const ref = useClickAway(() => {
+		onClose && onClose()
+	})
+
 	const containerStyle = useMemo(
 		() => ({
 			width,
@@ -33,15 +38,17 @@ const Modal = ({ children, width = '20rem', height, visible = false, onClose, ..
 	)
 
 	const el = useMemo(() => document.createElement('div'), [])
+
 	useEffect(() => {
 		document.body.appendChild(el)
 		return () => {
 			document.body.removeChild(el)
 		}
 	})
+
 	return ReactDOM.createPortal(
 		<BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
-			<ModalContainer {...props} style={{ ...props.style, ...containerStyle }}>
+			<ModalContainer ref={ref} {...props} style={{ ...props.style, ...containerStyle }}>
 				{children}
 			</ModalContainer>
 		</BackgroundDim>,

--- a/src/hooks/useClickAway.js
+++ b/src/hooks/useClickAway.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react'
+
+const events = ['mousedown', 'touchstart']
+
+const useClickAway = handler => {
+	const ref = useRef(null)
+	const saveHandler = useRef(handler)
+
+	useEffect(() => {
+		saveHandler.current = handler
+	}, [handler])
+
+	useEffect(() => {
+		const element = ref.current
+		if (!element) return
+
+		const handleEvent = e => {
+			!element.contains(e.target) && handler(e)
+		}
+
+		for (const eventName of events) {
+			document.addEventListener(eventName, handleEvent)
+		}
+
+		return () => {
+			for (const eventName of events) {
+				document.removeEventListener(eventName, handleEvent)
+			}
+		}
+	}, [ref, handler])
+
+	return ref
+}
+
+export default useClickAway

--- a/src/stories/Modal.stories.jsx
+++ b/src/stories/Modal.stories.jsx
@@ -4,15 +4,20 @@ import Modal from '../components/Modal'
 export default {
 	title: 'Component/Modal',
 	component: Modal,
+	argTypes: {
+		width: { defaultValue: 18.75, control: { type: 'number' } },
+		height: { control: { type: 'number' } },
+	},
 }
 
-export const Default = () => {
+export const Default = args => {
 	const [visible, setVisible] = useState(false)
 
 	return (
 		<div>
 			<button onClick={() => setVisible(true)}>show modal</button>
 			<Modal
+				{...args}
 				visible={visible}
 				onClose={() => {
 					setVisible(false)

--- a/src/stories/Modal.stories.jsx
+++ b/src/stories/Modal.stories.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import Modal from '../components/Modal'
+
+export default {
+	title: 'Component/Modal',
+	component: Modal,
+}
+
+export const Default = () => {
+	const [visible, setVisible] = useState(false)
+
+	return (
+		<div>
+			<button onClick={() => setVisible(true)}>show modal</button>
+			<Modal
+				visible={visible}
+				onClose={() => {
+					setVisible(false)
+				}}
+			>
+				Hi
+			</Modal>
+		</div>
+	)
+}


### PR DESCRIPTION
## 개요

![modal](https://user-images.githubusercontent.com/81891292/173195159-b42239aa-6dd5-4565-8349-3890396c84f0.PNG)

Modal 컴포넌트 구현했습니다.

## 작업 내용

### props

- width, height : number 입력시 rem으로 적용됩니다
- visible에 따라 보여질지 아닌지 결정됩니다.
  - 사용 하시는 곳에서 state로 visible 유지 하고 콜백으로 onClose에 setVisible(false) 적용 하시면 됩니다.
- 모달 외부 클릭하거나, 닫힘 버튼 누르시면 모달 닫히도록 구현했습니다.

