### PR TITLE
[기능구현, 페이지, FIX] 추가 클릭시 페이지 구현 및 시간 재생 에러 픽싱

### DIFF
--- a/src/atom.js
+++ b/src/atom.js
@@ -13,12 +13,12 @@ const localStorageEffect =
 	}
 export const timerState = atom({
 	key: 'timer',
-	default: {}, //{id:{time, name}}, anotherId: {time,name}}
+	default: {}, //{id:{time, name, isRunning}}, anotherId: {time,name, isRunning}}
 	effects: [localStorageEffect('timer')],
 })
 
-export const currentTimerState = atom({
-	key: 'currentTimer',
-	default: { id: 'root', name: '' },
-	effects: [localStorageEffect('currentTimer')],
-})
+// export const currentTimerState = atom({
+// 	key: 'currentTimerId',
+// 	default: { id: null, isRunning: false }, //id
+// 	effects: [localStorageEffect('currentTimer')],
+// })

--- a/src/components/TimeSelectForm.jsx
+++ b/src/components/TimeSelectForm.jsx
@@ -5,10 +5,10 @@ import Button from './Button'
 import Select from './Select'
 import Text from './Text'
 
-const HOUR_NUMBERS = Array.from({ length: 24 }, (_, i) => {
+export const HOUR_NUMBERS = Array.from({ length: 24 }, (_, i) => {
 	return { label: `${i}`, value: i }
 })
-const MINUTE_NUMBERS = Array.from({ length: 6 }, (_, i) => {
+export const MINUTE_NUMBERS = Array.from({ length: 6 }, (_, i) => {
 	return { label: `${i * 10}`, value: i * 10 }
 })
 

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -1,6 +1,6 @@
 import { useTimer } from 'react-timer-hook'
 import { useRecoilState } from 'recoil'
-import { combineState, currentTimerState, timerState } from '../atom'
+import { combineState, currentTimerIdState, currentTimerState, timerState } from '../atom'
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
 
@@ -11,41 +11,31 @@ export function Timer({ expiryTimestamp, autoStart = false, id, name, onClick })
 		autoStart,
 	})
 	const [timers, setTimers] = useRecoilState(timerState)
-	const [currentTimer, setCurrentTimer] = useRecoilState(currentTimerState)
 
 	useEffect(() => {
 		restart(expiryTimestamp, false)
 	}, [expiryTimestamp])
 
 	useEffect(() => {
-		setTimers({ ...timers, [id]: { name, time: hours * 60 * 60 + minutes * 60 + seconds } })
+		setTimers({
+			...timers,
+			[id]: { ...timers[id], time: hours * 60 * 60 + minutes * 60 + seconds },
+		})
 	}, [hours, minutes, seconds])
 
 	useEffect(() => {
-		if (currentTimer.id !== id) pause()
-	}, [currentTimer])
-
+		if (timers[id].isRunning) {
+			resume()
+		} else {
+			pause()
+		}
+	}, [timers])
 	return (
-		<TimerWrapper
-			id={id}
-			onClick={() => {
-				if (onClick === undefined) {
-					if (!isRunning) {
-						resume()
-						setCurrentTimer({ id, name })
-					} else {
-						pause()
-						setCurrentTimer({ id: null, name: null })
-					}
-				} else {
-					onClick()
-				}
-			}}
-			isRunning={isRunning}
-		>
+		<TimerWrapper id={id} onClick={onClick} isRunning={isRunning}>
 			<Name>{name}</Name>
 			<Time>
 				<span>{hours}</span>:<span>{minutes}</span>:<span>{seconds}</span>
+				<div>{isRunning ? '실행중' : '정지'}</div>
 			</Time>
 		</TimerWrapper>
 	)

--- a/src/pages/addToDoTimeDivider.jsx
+++ b/src/pages/addToDoTimeDivider.jsx
@@ -5,7 +5,8 @@ import NavBar from '../components/NavBar'
 import { Timer } from '../components/Timer'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
-import TimeSelectForm from '../components/TimeSelectForm'
+import TimeSelectForm, { HOUR_NUMBERS, MINUTE_NUMBERS } from '../components/TimeSelectForm'
+import Select from '../components/Select'
 
 export const AddToDoTimeDivider = () => {
 	const [timers, setTimers] = useRecoilState(timerState)
@@ -40,8 +41,8 @@ export const AddToDoTimeDivider = () => {
 					}}
 				>
 					할 일: <input name={'name'} required={true} type={'text'} maxLength={10} />
-					몇 시간 : <input name={'hour'} required={true} type={'number'} maxLength={2} max={23} />
-					몇 분: <input name={'minute'} required={true} type={'number'} maxLength={2} max={59} />
+					몇 시간 : <Select name={'hour'} data={HOUR_NUMBERS} />
+					몇 분: <Select name={'minute'} data={MINUTE_NUMBERS} />
 					<button>생성하기</button>
 				</form>
 			</Modal>

--- a/src/pages/addToDoTimeDivider.jsx
+++ b/src/pages/addToDoTimeDivider.jsx
@@ -1,11 +1,64 @@
 import React from 'react'
+import { useRecoilState } from 'recoil'
+import { timerState } from '../atom'
+import NavBar from '../components/NavBar'
+import { Timer } from '../components/Timer'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+import TimeSelectForm from '../components/TimeSelectForm'
 
 export const AddToDoTimeDivider = () => {
+	const [timers, setTimers] = useRecoilState(timerState)
 	return (
 		<>
-			<h2>AddToDoTimeDivider</h2>
+			<NavBar backIcon>모래시계 편집하기</NavBar>
+			<Link to="/doneTodo">완료하기</Link>
+			<Link to="/addTodo">추가하기</Link>
+			<TimerArea>
+				{Object.entries(timers).map(([id, { time, name }], index) => {
+					return (
+						<Timer
+							onClick={() => {}}
+							key={id}
+							id={id}
+							name={name}
+							expiryTimestamp={new Date(new Date().getTime() + time * 1000)}
+						/>
+					)
+				})}
+			</TimerArea>
+			<Modal>
+				<form
+					onSubmit={e => {
+						e.preventDefault()
+						const [name, time, id] = [
+							e.target.name.value,
+							e.target.hour.value * 60 * 60 + e.target.minute.value * 60,
+							'' + Date.now(),
+						]
+						setTimers({ ...timers, [id]: { time, name } })
+					}}
+				>
+					할 일: <input name={'name'} required={true} type={'text'} maxLength={10} />
+					몇 시간 : <input name={'hour'} required={true} type={'number'} maxLength={2} max={23} />
+					몇 분: <input name={'minute'} required={true} type={'number'} maxLength={2} max={59} />
+					<button>생성하기</button>
+				</form>
+			</Modal>
 		</>
 	)
 }
 
 export default AddToDoTimeDivider
+const TimerArea = styled.div`
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	width: 100%;
+	height: 30rem;
+`
+const Modal = styled.div`
+	width: 100%;
+	height: 10rem;
+	background-color: aliceblue;
+`

--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -7,6 +7,8 @@ import TaskBox from '../components/TaskBox'
 import Text from '../components/Text'
 import TimeSelectForm from '../components/TimeSelectForm'
 import { convertHourMinuteToSeconds, convertSecondsToHourMinute } from '../utils/convertTime'
+import { useRecoilState } from 'recoil'
+import { timerState } from '../atom'
 
 const BUTTON_TEXT = Object.freeze({
 	VALID: '다음 단계',
@@ -28,6 +30,9 @@ const BoxContainer = styled.div`
 
 export const CreateTimeDivider = () => {
 	const location = useLocation()
+
+	const [timers, setTimers] = useRecoilState(timerState)
+
 	const initialTotal = convertHourMinuteToSeconds(location.state.spareTime)
 	const [totalTime, setTotalTime] = useState(convertHourMinuteToSeconds(location.state.spareTime))
 	const [isTimeOver, setIsTimeOver] = useState(false)
@@ -84,7 +89,17 @@ export const CreateTimeDivider = () => {
 			{isTimeOver && <Text color={'red'}>남은 시간이 부족합니다.</Text>}
 			<ButtonArea>
 				<Link to="/updateTimeDivider" state={{ tasks }}>
-					<Button>{BUTTON_TEXT.VALID}</Button>
+					<Button
+						onClick={() => {
+							const newTimers = {}
+							tasks.forEach(
+								({ id, task, time, hour, minute }) => (newTimers[id] = { name: task, time }),
+							)
+							setTimers(newTimers)
+						}}
+					>
+						{BUTTON_TEXT.VALID}
+					</Button>
 				</Link>
 			</ButtonArea>
 		</>

--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -93,7 +93,8 @@ export const CreateTimeDivider = () => {
 						onClick={() => {
 							const newTimers = {}
 							tasks.forEach(
-								({ id, task, time, hour, minute }) => (newTimers[id] = { name: task, time }),
+								({ id, task, time, hour, minute }) =>
+									(newTimers[id] = { name: task, time, isRunning: false }),
 							)
 							setTimers(newTimers)
 						}}

--- a/src/pages/updateTimeDivider.jsx
+++ b/src/pages/updateTimeDivider.jsx
@@ -1,26 +1,12 @@
 import React, { useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import NavBar from '../components/NavBar'
 import { useRecoilState } from 'recoil'
 import { timerState } from '../atom'
 import { Timer } from '../components/Timer'
 const UpdateTimeDivider = () => {
-	const dummyData = [
-		{ id: '123', name: '밥 묵자', time: 600 },
-		{ id: '234', name: '치킨 묵자', time: 1200 },
-		{ id: '345', name: '피자 묵자', time: 1800 },
-		{ id: '456', name: '삼겹살 묵자', time: 2400 },
-		{ id: '567', name: '홍차 마시자', time: 3000 },
-		{ id: '678', name: '잠이나 자자', time: 3600 },
-	]
 	const [timers, setTimers] = useRecoilState(timerState)
-
-	useEffect(() => {
-		const newTimers = {}
-		dummyData.forEach(({ id, name, time }) => (newTimers[id] = { name, time }))
-		setTimers(newTimers)
-	}, [])
 
 	return (
 		<>

--- a/src/pages/updateTimeDivider.jsx
+++ b/src/pages/updateTimeDivider.jsx
@@ -3,16 +3,29 @@ import { Link, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import NavBar from '../components/NavBar'
 import { useRecoilState } from 'recoil'
-import { timerState } from '../atom'
+import { currentTimerIdState, currentTimerState, timerState } from '../atom'
 import { Timer } from '../components/Timer'
 const UpdateTimeDivider = () => {
 	const [timers, setTimers] = useRecoilState(timerState)
-
+	const stopAllTimers = () => {
+		const newTimers = Object.assign({}, timers)
+		for (const timerId in newTimers) {
+			newTimers[timerId] = {
+				...newTimers[timerId],
+				isRunning: false,
+			}
+		}
+		setTimers(newTimers)
+	}
 	return (
 		<>
 			<NavBar backIcon>모래시계 편집하기</NavBar>
-			<Link to="/doneTodo">완료하기</Link>
-			<Link to="/addTodo">추가하기</Link>
+			<Link to="/doneTodo" onClick={() => stopAllTimers()}>
+				완료하기
+			</Link>
+			<Link to="/addTodo" onClick={() => stopAllTimers()}>
+				추가하기
+			</Link>
 			<TimerArea>
 				{Object.entries(timers).map(([id, { time, name }], index) => (
 					<Timer
@@ -20,6 +33,16 @@ const UpdateTimeDivider = () => {
 						id={id}
 						name={name}
 						expiryTimestamp={new Date(new Date().getTime() + time * 1000)}
+						onClick={() => {
+							const newTimers = Object.assign({}, timers)
+							for (const timerId in newTimers) {
+								newTimers[timerId] = {
+									...newTimers[timerId],
+									isRunning: timerId === id ? !newTimers[id].isRunning : false,
+								}
+							}
+							setTimers(newTimers)
+						}}
 					/>
 				))}
 			</TimerArea>


### PR DESCRIPTION
## 개요
1. 추가 클릭시 페이지를 구현하였습니다.
2. 전역 상태에서 `currentTimerState` 가 사라지고 `timerState`에 `isRunning` 이라는 속성으로 통합되었습니다.
```js
//현재 timerState의 형태
timerState = {
  id: {
    time: number,
    name: string,
    isRunning: boolean,
  }
}
```
3. 시간 재생이 정상적으로 이루어지지 않던 에러를 고쳤습니다.
4. 편집하기 페이지에서 완료하기, 추가하기 페이지로 이동시 모든 타이머는 정지되도록 하였습니다.
## 작업 내용
<img width="488" alt="image" src="https://user-images.githubusercontent.com/54318460/173195305-834fafe4-f91c-43af-bc5b-f9b4d5d46dc9.png">

## 관련 이슈

## 참고 자료
