### PR TITLE
[스타일] container 크기 수정 및 마이너 수정

### DIFF
--- a/src/shared/constants/colors.js
+++ b/src/shared/constants/colors.js
@@ -1,4 +1,4 @@
-const palette = {
+export const palette = {
 	tossBlue: '#4880EE',
 	labelGray: '#F8F9FA',
 	completeGreen: '#5ABF83',
@@ -7,7 +7,7 @@ const palette = {
 	white: '#FFFFFF',
 }
 
-const colors = {
+export const colors = {
 	primary: palette.tossBlue,
 	background: palette.white,
 	font: palette.black,

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,5 +1,6 @@
 import reset from 'styled-reset'
 import { createGlobalStyle } from 'styled-components'
+import { colors } from '../shared/constants/colors'
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
@@ -64,12 +65,14 @@ table {
   box-sizing: border-box;
   align-items: center;
   width: 100%;
-  max-width: 420px;
-  height: 100vh;
+  max-width: 375px;
+  height: 812px;
   margin: auto;
+  margin-top: 2rem;
   padding: 0;
   overflow: hidden;
-  background-color: #f1f0f7;
+  box-shadow: 0 0 2rem 0.1rem rgba(0, 0, 0, 0.2);
+  background-color: ${colors.background};
 }
 `
 


### PR DESCRIPTION
## 개요
작업을 용이하게 하기 위해, 전체 container의 크기를 Figma 상의 프레임과 동일하게 설정하였습니다.

## 작업 내용
1. container 크기 고정
2. colors 의 export 누락 수정
## 관련 이슈

## 참고 자료
