### PR TITLE
[컴포넌트] Select 컴포넌트 디자인 수정

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,22 @@
+import GlobalStyle from '../src/styles/GlobalStyle'
+
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
-    },
-  },
+	actions: { argTypesRegex: '^on[A-Z].*' },
+	controls: {
+		matchers: {
+			color: /(background|color)$/i,
+			date: /Date$/,
+		},
+	},
 }
+
+export const decorators = [
+	Story => {
+		return (
+			<>
+				<GlobalStyle />
+				<Story />
+			</>
+		)
+	},
+]

--- a/src/shared/components/Select.jsx
+++ b/src/shared/components/Select.jsx
@@ -1,3 +1,4 @@
+import { colors } from 'shared/constants/colors'
 import styled from 'styled-components'
 
 const Select = ({
@@ -50,6 +51,7 @@ export default Select
 
 const Wrapper = styled.div`
 	display: ${({ block }) => (block ? 'block' : 'inline-block')};
+	border-bottom: 1px solid ${colors.tossBlue};
 `
 
 const Label = styled.label`
@@ -58,10 +60,15 @@ const Label = styled.label`
 `
 
 const StyledSelect = styled.select`
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	border: none;
 	width: 100%;
-	padding: 0.5rem 0.8rem;
-	margin: 0.5rem 0;
-	border: ${({ invalid }) => (invalid ? '0.1rem solid red' : '0.1rem solid #00dfab')};
+	padding: 0.8rem 1rem;
+	outline: none;
+	border-radius: 0;
+	margin: 0;
 	border-radius: 4px;
 	box-sizing: border-box;
 `

--- a/src/shared/components/Select.jsx
+++ b/src/shared/components/Select.jsx
@@ -1,16 +1,16 @@
 import { colors } from 'shared/constants/colors'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 
 const Select = ({
 	data,
 	label,
-	style,
+	fontSize = 2.4,
 	placeholder,
 	block = false,
 	invalid = false,
 	required = false,
 	disabled = false,
-	wrapperProps,
 	...props
 }) => {
 	const formattedData = data.map(item =>
@@ -32,19 +32,30 @@ const Select = ({
 	}
 
 	return (
-		<Wrapper block={block} {...wrapperProps}>
+		<Wrapper block={block}>
 			<Label>{label}</Label>
 			<StyledSelect
-				style={style}
+				{...props}
+				{...props.style}
+				fontSize={fontSize}
 				invalid={invalid}
 				required={required}
 				disabled={disabled}
-				{...props}
 			>
 				{options}
 			</StyledSelect>
 		</Wrapper>
 	)
+}
+
+Select.propTypes = {
+	fontSize: PropTypes.number,
+	backgroundColor: PropTypes.string,
+	placeholder: PropTypes.string,
+	block: PropTypes.bool,
+	invalid: PropTypes.bool,
+	required: PropTypes.bool,
+	disabled: PropTypes.bool,
 }
 
 export default Select
@@ -64,6 +75,7 @@ const StyledSelect = styled.select`
 	-moz-appearance: none;
 	appearance: none;
 	border: none;
+	font-size: ${props => `${props.fontSize}rem`};
 	width: 100%;
 	padding: 0.8rem 1rem;
 	outline: none;

--- a/src/stories/Select.stories.jsx
+++ b/src/stories/Select.stories.jsx
@@ -5,7 +5,6 @@ export default {
 	component: Select,
 	argTypes: {
 		label: {
-			defaultValue: 'Label',
 			control: 'text',
 		},
 		placeholder: {
@@ -33,7 +32,6 @@ export default {
 
 export const Default = args => (
 	<div>
-		<Select data={['Item 1', 'Item 2', { label: 'Item 3', value: 'value' }]} {...args} />
 		<Select data={['Item 1', 'Item 2', { label: 'Item 3', value: 'value' }]} {...args} />
 	</div>
 )

--- a/src/stories/Select.stories.jsx
+++ b/src/stories/Select.stories.jsx
@@ -32,5 +32,8 @@ export default {
 }
 
 export const Default = args => (
-	<Select data={['Item 1', 'Item 2', { label: 'Item 3', value: 'value' }]} {...args} />
+	<div>
+		<Select data={['Item 1', 'Item 2', { label: 'Item 3', value: 'value' }]} {...args} />
+		<Select data={['Item 1', 'Item 2', { label: 'Item 3', value: 'value' }]} {...args} />
+	</div>
 )


### PR DESCRIPTION
## 개요

피그마 디자인 명세에 맞게 Select 디자인을 수정했습니다.

추가로 Storybook과 App 간의 Global Style이 달라 서로 나타나는 디자인에 차이가 발생했었는데

Storybook에 글로벌 스타일 적용해서 해결했습니다.

## 작업 내용

-fontSize : number 타입으로 자동 rem 변환 적용 됩니다.
- block: bool 타입으로 디스플레이 설정합니다.
