### PR TITLE
[페이지/디자인] create time divider 페이지 스타일 적용

### DIFF
--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -85,7 +85,11 @@ export const CreateTimeDivider = () => {
 				</Text>
 			</SubTitle>
 			<TimeSection>
-				<Text size={2.2} color={themeColors.primary}>
+				<Text
+					size={2.0}
+					color={themeColors.primary}
+					style={{ color: themeColors.primary, fontSize: '2.0rem', marginBottom: '1rem' }}
+				>
 					남은 분배 가능 시간
 				</Text>
 				<Text size={3.5}>
@@ -106,9 +110,14 @@ export const CreateTimeDivider = () => {
 					))}
 				</BoxContainer>
 			</TaskArea>
-
-			{selectedTask && <TimeSelectForm targetTask={selectedTask} onSubmit={handleSubmit} />}
-			{isTimeOver && <Text color="red">남은 시간이 부족합니다.</Text>}
+			<FormSection>
+				{selectedTask && <TimeSelectForm targetTask={selectedTask} onSubmit={handleSubmit} />}
+				{isTimeOver && (
+					<Text color="red" size={1.4}>
+						남은 시간이 부족합니다.
+					</Text>
+				)}
+			</FormSection>
 			<ButtonArea>
 				<Link to="/updateTimeDivider" state={{ tasks }}>
 					<Button onClick={handleNextPageClick}>{BUTTON_TEXT.VALID}</Button>
@@ -133,6 +142,7 @@ const BoxContainer = styled.div`
 	display: flex;
 	width: 100%;
 	flex-wrap: wrap;
+	justify-content: center;
 `
 
 const SubTitle = styled.span`
@@ -155,7 +165,20 @@ const TimeSection = styled.section`
 	line-height: 3.2rem;
 	text-align: center;
 	margin-top: 2.4rem;
+	margin-bottom: 2.4rem;
 `
+
+const FormSection = styled.section`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	width: 26rem;
+	line-height: 3.2rem;
+	text-align: center;
+	margin-top: 4.8rem;
+	margin-bottom: 2.4rem;
+`
+
 const TaskArea = styled.div`
 	position: relative;
 	width: 100%;
@@ -164,6 +187,10 @@ const TaskArea = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	align-items: flex-start;
-	margin: 2rem 3rem 1rem 3rem;
-	margin-bottom: 2rem;
+	padding: 1rem;
+	box-sizing: border-box;
+
+	::-webkit-scrollbar {
+		display: none;
+	}
 `

--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -9,6 +9,7 @@ import TimeSelectForm from 'shared/components/TimeSelectForm'
 import { convertHourMinuteToSeconds, convertSecondsToHourMinute } from 'shared/utils/convertTime'
 import { useSetRecoilState } from 'recoil'
 import { timerObject, timerState } from 'atom'
+import { themeColors } from 'shared/constants/colors'
 
 const BUTTON_TEXT = Object.freeze({
 	VALID: '다음 단계',
@@ -77,22 +78,35 @@ export const CreateTimeDivider = () => {
 
 	return (
 		<>
-			<NavBar backIcon>시간을 분배해요</NavBar>
-			<Text size={3.5}>
-				{convertSecondsToHourMinute(totalTime).hour} :{' '}
-				{convertSecondsToHourMinute(totalTime).minute}
-			</Text>
-			<BoxContainer>
-				{tasks.map(task => (
-					<TaskBox
-						key={task.id}
-						task={task}
-						onClick={() => {
-							handleTaskBoxClick(task)
-						}}
-					/>
-				))}
-			</BoxContainer>
+			<NavBar backIcon />
+			<SubTitle>
+				<Text style={{ textAlign: 'start', fontSize: '2.2rem', padding: '0 3rem' }}>
+					오늘 해야할 일들에 시간을 분배하세요.
+				</Text>
+			</SubTitle>
+			<TimeSection>
+				<Text size={2.2} color={themeColors.primary}>
+					남은 분배 가능 시간
+				</Text>
+				<Text size={3.5}>
+					{convertSecondsToHourMinute(totalTime).hour} :{' '}
+					{convertSecondsToHourMinute(totalTime).minute}
+				</Text>
+			</TimeSection>
+			<TaskArea>
+				<BoxContainer>
+					{tasks.map(task => (
+						<TaskBox
+							key={task.id}
+							task={task}
+							onClick={() => {
+								handleTaskBoxClick(task)
+							}}
+						/>
+					))}
+				</BoxContainer>
+			</TaskArea>
+
 			{selectedTask && <TimeSelectForm targetTask={selectedTask} onSubmit={handleSubmit} />}
 			{isTimeOver && <Text color="red">남은 시간이 부족합니다.</Text>}
 			<ButtonArea>
@@ -119,4 +133,37 @@ const BoxContainer = styled.div`
 	display: flex;
 	width: 100%;
 	flex-wrap: wrap;
+`
+
+const SubTitle = styled.span`
+	position: relative;
+	left: -5rem;
+	display: flex;
+	flex-direction: column;
+	align-items: left;
+	width: 24.5rem;
+	line-height: 3.2rem;
+	text-align: center;
+`
+
+const TimeSection = styled.section`
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: left;
+	width: 24.5rem;
+	line-height: 3.2rem;
+	text-align: center;
+	margin-top: 2.4rem;
+`
+const TaskArea = styled.div`
+	position: relative;
+	width: 100%;
+	height: 20vh;
+	overflow-y: scroll;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	margin: 2rem 3rem 1rem 3rem;
+	margin-bottom: 2rem;
 `

--- a/src/pages/createTimeDivider.jsx
+++ b/src/pages/createTimeDivider.jsx
@@ -46,6 +46,12 @@ export const CreateTimeDivider = () => {
 		return totalTime + currentTime - inputTime >= 0 ? true : false
 	}
 
+	const addZero = () => {
+		return convertSecondsToHourMinute(totalTime).hour.length === 1
+			? `0${convertSecondsToHourMinute(totalTime).hour}`
+			: convertSecondsToHourMinute(totalTime).hour
+	}
+
 	const handleSubmit = time => {
 		const { hour, minute } = time
 		const inputTime = convertHourMinuteToSeconds(time)
@@ -93,8 +99,10 @@ export const CreateTimeDivider = () => {
 					남은 분배 가능 시간
 				</Text>
 				<Text size={3.5}>
-					{convertSecondsToHourMinute(totalTime).hour} :{' '}
-					{convertSecondsToHourMinute(totalTime).minute}
+					{addZero()} :{' '}
+					{convertSecondsToHourMinute(totalTime).minute === '0'
+						? '00'
+						: convertSecondsToHourMinute(totalTime).minute}
 				</Text>
 			</TimeSection>
 			<TaskArea>

--- a/src/shared/components/Select.jsx
+++ b/src/shared/components/Select.jsx
@@ -18,7 +18,7 @@ const Select = ({
 	)
 
 	const options = formattedData.map(item => (
-		<option key={item.value} value={item.value}>
+		<option style={{ fontSize: '1.5rem' }} key={item.value} value={item.value}>
 			{item.label}
 		</option>
 	))

--- a/src/shared/components/TaskBox.jsx
+++ b/src/shared/components/TaskBox.jsx
@@ -1,17 +1,18 @@
-import { colors, themeColors } from 'shared/constants/colors'
+import { themeColors } from 'shared/constants/colors'
 import styled from 'styled-components'
 import Text from './Text'
 
 const TaskBox = ({ task, ...props }) => {
 	const { hour, minute } = task
+
 	return (
 		<BoxContainer {...props}>
 			<BoxWrapper>
-				<Text size={1.3} color={themeColors.primary}>
+				<Text size={1.4} color={themeColors.primary}>
 					{task.task}
 				</Text>
-				<Text size={1.3}>
-					{hour} : {minute}
+				<Text style={{ marginTop: '0.8rem', fontSize: '1.4rem' }}>
+					{hour.length === 1 ? `0${hour}` : hour} : {minute === '0' ? '00' : minute}
 				</Text>
 			</BoxWrapper>
 		</BoxContainer>

--- a/src/shared/components/TaskBox.jsx
+++ b/src/shared/components/TaskBox.jsx
@@ -1,27 +1,38 @@
+import { colors, themeColors } from 'shared/constants/colors'
 import styled from 'styled-components'
 import Text from './Text'
 
 const TaskBox = ({ task, ...props }) => {
 	const { hour, minute } = task
 	return (
-		<BoxWrapper {...props}>
-			<div>{task.task}</div>
-			<Text>
-				{hour} : {minute}
-			</Text>
-		</BoxWrapper>
+		<BoxContainer {...props}>
+			<BoxWrapper>
+				<Text size={1.3} color={themeColors.primary}>
+					{task.task}
+				</Text>
+				<Text size={1.3}>
+					{hour} : {minute}
+				</Text>
+			</BoxWrapper>
+		</BoxContainer>
 	)
 }
 
 export default TaskBox
+
+const BoxContainer = styled.div`
+	padding: 1.6rem 1.6rem;
+	background-color: ${themeColors.labelBackground};
+	cursor: pointer;
+	margin-right: 0.5rem;
+	margin-bottom: 0.5rem;
+	border-radius: 1rem;
+	box-sizing: border-box;
+`
 
 const BoxWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	cursor: pointer;
-	border: 1px solid;
-	overflow: hidden;
-	width: 8.6rem;
 `

--- a/src/shared/components/TimeSelectForm.jsx
+++ b/src/shared/components/TimeSelectForm.jsx
@@ -33,7 +33,7 @@ const TimeSelectForm = ({ targetTask, onSubmit, ...props }) => {
 
 	return (
 		<Form {...props} onSubmit={handleSubmit}>
-			<Text size={2.2} block>
+			<Text size={2.2} strong block>
 				{targetTask.task}
 			</Text>
 			<Content>

--- a/src/shared/components/TimeSelectForm.jsx
+++ b/src/shared/components/TimeSelectForm.jsx
@@ -33,32 +33,29 @@ const TimeSelectForm = ({ targetTask, onSubmit, ...props }) => {
 
 	return (
 		<Form {...props} onSubmit={handleSubmit}>
-			<Text>{targetTask.task}</Text>
-			<Select
-				name="hour"
-				value={time.hour}
-				data={HOUR_NUMBERS}
-				label="시간"
-				onChange={handleChange}
-			/>
-			<Select
-				name="minute"
-				value={time.minute}
-				data={MINUTE_NUMBERS}
-				label="분"
-				onChange={handleChange}
-			/>
-			<Button width={7.9} height={3.9} fontSize={1.6}>
-				Set
-			</Button>
+			<Text size={2.2} block>
+				{targetTask.task}
+			</Text>
+			<Content>
+				<Select name="hour" value={time.hour} data={HOUR_NUMBERS} onChange={handleChange} />
+				<Text size={1.4}>시간</Text>
+				<Select name="minute" value={time.minute} data={MINUTE_NUMBERS} onChange={handleChange} />
+				<Text size={1.4}>분</Text>
+				<Button width={7.9} height={3.9} fontSize={1.6}>
+					Set
+				</Button>
+			</Content>
 		</Form>
 	)
 }
 
 export default TimeSelectForm
 
-const Form = styled.form`
+const Form = styled.form``
+
+const Content = styled.div`
 	display: flex;
 	align-items: flex-end;
+	justify-content: center;
 	gap: 1rem;
 `

--- a/src/shared/constants/colors.js
+++ b/src/shared/constants/colors.js
@@ -1,18 +1,18 @@
 export const colors = {
-    blue: '#4880EE',
-    labelGray: '#F8F9FA',
-    completeGreen: '#5ABF83',
-    timeoutDarkGray: '#505866',
-    lightGray: '#919191',
-    black: '#000000',
-    white: '#FFFFFF',
+	blue: '#4880EE',
+	labelGray: '#F8F9FA',
+	completeGreen: '#5ABF83',
+	timeoutDarkGray: '#505866',
+	lightGray: '#919191',
+	black: '#000000',
+	white: '#FFFFFF',
 }
 
 export const themeColors = {
-    primary: colors.blue,
-    background: colors.white,
-    font: colors.black,
-    fontReversed: colors.white,
-    fontDescription: colors.lightGray,
-    labelBackground: colors.labelGray,
+	primary: colors.blue,
+	background: colors.white,
+	font: colors.black,
+	fontReversed: colors.white,
+	fontDescription: colors.lightGray,
+	labelBackground: colors.labelGray,
 }


### PR DESCRIPTION
## 개요
Close #47 

![page](https://user-images.githubusercontent.com/81891292/173506926-fc32c18e-fd82-4f02-a25d-78d2db7c2833.PNG)

피그마 디자인 명세에 맞춰 시간 분배 페이지 구현했습니다.

작동상의 문제는 없으나 코드가 다시 지저분해져서 중간 영상제작 이후에 리팩터링 하겠습니다.

박스 클릭시 모달을 띄워 입력을 받는 방식을 고려하였는데, 
사용자 경험상 더 번거롭지 않을까 하는 생각이 들어서 우선 기존 형태로 시간 분배 입력 받도록 구현했습니다.

어떤 방식이 더 나은지에 대해 공유해 주시면 좋을 것 같습니다!



## 작업 내용
- 페이지 레이아웃 설정
- Component 디자인 설정

추가
- selectOptions 폰트 사이즈 축소
