### PR TITLE
[페이지] 로그아웃 기능 구현

### DIFF
--- a/src/pages/MyPage/index.js
+++ b/src/pages/MyPage/index.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react'
-import { colors, themeColors } from '../../shared/constants/colors'
+import React from 'react'
+import { themeColors } from '../../shared/constants/colors'
 import Text from '../../shared/components/Text'
 import { ToggleButton } from '../../shared/components/ToggleButton'
 import {
@@ -15,26 +15,15 @@ import {
 } from './style'
 import { BottomBar } from '../../shared/components/BottomBar'
 import { IoIosArrowForward } from 'react-icons/io'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useUser } from '../../shared/hooks/useUser'
 import Avatar from '../../shared/components/Avatar'
-import { useNavigate } from 'react-router-dom'
 
-const dummyUser = {
-	profileImg: 'https://tva1.sinaimg.cn/large/e6c9d24egy1h3bief308rj20dw0dwwem.jpg',
-	name: '김경현',
-	email: 'codeisneverodd@gmail.com',
-	shareAllowed: false,
-}
 const MyPage = () => {
 	const { user, logout } = useUser()
 	const navigate = useNavigate()
-	// const [user, setUser] = useState(dummyUser)
-	const handleToggle = toggled => {
-		// const newUser = Object.assign({}, user)
-		// newUser.shareAllowed = toggled
-		// setUser(newUser)
-	}
+
+	const handleToggle = toggled => {}
 	const handleLogOut = async () => {
 		const { isSuccess, message } = await logout()
 		if (isSuccess) {

--- a/src/pages/MyPage/index.js
+++ b/src/pages/MyPage/index.js
@@ -1,9 +1,8 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { colors, themeColors } from '../../shared/constants/colors'
 import Text from '../../shared/components/Text'
 import { ToggleButton } from '../../shared/components/ToggleButton'
 import {
-	Avatar,
 	BottomBarArea,
 	Icon,
 	LogOut,
@@ -17,6 +16,9 @@ import {
 import { BottomBar } from '../../shared/components/BottomBar'
 import { IoIosArrowForward } from 'react-icons/io'
 import { Link } from 'react-router-dom'
+import { useUser } from '../../shared/hooks/useUser'
+import Avatar from '../../shared/components/Avatar'
+import { useNavigate } from 'react-router-dom'
 
 const dummyUser = {
 	profileImg: 'https://tva1.sinaimg.cn/large/e6c9d24egy1h3bief308rj20dw0dwwem.jpg',
@@ -25,25 +27,29 @@ const dummyUser = {
 	shareAllowed: false,
 }
 const MyPage = () => {
-	const [user, setUser] = useState(dummyUser)
+	const { user, logout } = useUser()
+	const navigate = useNavigate()
+	// const [user, setUser] = useState(dummyUser)
 	const handleToggle = toggled => {
-		const newUser = Object.assign({}, user)
-		newUser.shareAllowed = toggled
-		setUser(newUser)
+		// const newUser = Object.assign({}, user)
+		// newUser.shareAllowed = toggled
+		// setUser(newUser)
 	}
-	const handleLogOut = () => {
-		//로그아웃 액션
+	const handleLogOut = async () => {
+		const { isSuccess, message } = await logout()
+		if (isSuccess) {
+			alert(message)
+			navigate('/')
+		}
 	}
 	return (
 		<Wrapper>
 			<LogOutWrapper>
-				<LogOut as={Link} onClick={handleLogOut} to={'/'}>
-					로그아웃
-				</LogOut>
+				<LogOut onClick={handleLogOut}>로그아웃</LogOut>
 			</LogOutWrapper>
 			<Profiles>
-				<Avatar src={user.profileImg} alt="avatar" size={10.5} />
-				<Text size={2.2}>{user.name}</Text>
+				<Avatar src={user?.profileImg} alt="avatar" size={10.5} />
+				<Text size={2.2}>{user.fullName}</Text>
 				<Text size={1.3} color={themeColors.fontDescription}>
 					{user.email}
 				</Text>

--- a/src/pages/MyPage/style.js
+++ b/src/pages/MyPage/style.js
@@ -76,4 +76,5 @@ export const LogOut = styled.div`
 	font-size: 1.3rem;
 	background-color: ${colors.white};
 	color: ${colors.red};
+	cursor: pointer;
 `

--- a/src/shared/api/apis/authApis.js
+++ b/src/shared/api/apis/authApis.js
@@ -25,3 +25,9 @@ export const signup = async (userInfo = { email: null, fullName: 'unknown', pass
 		return { isSuccess, message }
 	}
 }
+
+export const requestLogout = async () => {
+	const { isSuccess, data } = await API.post('/logout')
+
+	return { isSuccess, message: data }
+}

--- a/src/shared/hooks/useUser.js
+++ b/src/shared/hooks/useUser.js
@@ -1,24 +1,29 @@
 import { useState } from 'react'
+import { useRecoilValue, useResetRecoilState } from 'recoil'
+import { loginUserState } from '../../state/user'
+import { requestLogout } from '../api/apis/authApis'
 
-const dummyUser = {
-	profileImg: 'https://tva1.sinaimg.cn/large/e6c9d24egy1h3bief308rj20dw0dwwem.jpg',
-	name: '김경현',
-	email: 'codeisneverodd@gmail.com',
-	shareAllowed: false,
-}
 export const useUser = () => {
-	const [user, setUser] = useState(dummyUser)
+	const loginData = useRecoilValue(loginUserState)
+	const removeLoginData = useResetRecoilState(loginUserState)
+	const [user, setUser] = useState(loginData.user)
 
-	const changeName = name => {
-		setUser({ ...user, name })
+	const changeName = fullName => {
+		setUser({ ...user, fullName })
 	}
 	const changeEmail = email => {
 		setUser({ ...user, email })
+	}
+	const logout = async () => {
+		const response = await requestLogout()
+		removeLoginData()
+		return response
 	}
 
 	return {
 		user,
 		changeName,
 		changeEmail,
+		logout,
 	}
 }


### PR DESCRIPTION
## 개요
로그아웃 클릭시, 로그아웃 요청을 하고 성공시 
1. 세션의 유저 정보가 (전역상태 리셋을 통해) 삭제됩니다.
2. 사용자에게 성공여부를 alert 후, 성공시   시작화면으로 돌아갑니다.
<img width="481" alt="image" src="https://user-images.githubusercontent.com/54318460/174596216-2b7270c5-c8f4-41f0-81ea-1ff146e2ef63.png">

## 작업 내용
- 로그아웃 기능 구현 d6ad508e66be713f943329e8155d7eb82e933a07 d27091f3c6cba6a8095a1f0f2dfdfb317344f871

## 관련 이슈
- 로그인 시 유저 정보에는 프로필 이미지가 포함되지않고, 추측이지만 이미지 업로드를 해야 이미지필드가 생기는 것 같습니다. (현재는 이미지가 없으면, placeholder 없이 그냥 보이지 않고 자리만 차지하도록 구현되어있습니다. 향후 수정할 것 입니다.)
- 로그아웃은 request body에 담는 값이 없는데 어떤 기준으로 로그아웃을 하는 것인가요? 실제로 로그인을 하지 않고, 로그아웃을 하여도 성공적인 response를 받습니다.

## 참고 자료
