### PR TITLE
[FIX] 회원 가입 후 API 호출 수정

### DIFF
--- a/src/shared/api/apis/postApis.js
+++ b/src/shared/api/apis/postApis.js
@@ -1,7 +1,8 @@
 import { TEST_CHANNEL_ID } from 'shared/constants/chanelId'
 import API from '../API'
-
+import axios from 'axios'
 export const createPost = async (
+	token,
 	postInfo = {
 		title: JSON.stringify({ share: 'PRIVATE', timers: [] }),
 		image: null,
@@ -9,8 +10,17 @@ export const createPost = async (
 	},
 ) => {
 	try {
-		await API.post('/posts/create', postInfo)
-		return
+		/**
+		@description recoil의 state effect를 이용한 sesseionStorage 데이터 세팅 시점과 동기화 불가능하여 임시처리
+		TODO: 리팩토링 필요한 API 호출
+		*/
+		const { data } = await axios.post('/posts/create', postInfo, {
+			baseURL: process.env.REACT_APP_API_BASE_URL + process.env.REACT_APP_PORT,
+			timeout: 5000,
+			headers: { Authorization: `bearer ${token}`, 'Content-Type': 'application/json' },
+		})
+
+		return data
 	} catch (error) {
 		return error
 	}

--- a/src/shared/hooks/useUser.js
+++ b/src/shared/hooks/useUser.js
@@ -2,7 +2,7 @@ import { useRecoilState, useResetRecoilState } from 'recoil'
 import { loginDataState, userState } from 'state/user'
 import { requestSignup, requestLogin, requestLogout } from 'shared/api/apis/authApis'
 import { getUser, requestChangeFullName, uploadImage } from 'shared/api/apis/userApis'
-import { createPost, deletePost } from 'shared/api/apis/postApis'
+import { createPost } from 'shared/api/apis/postApis'
 import { useTimers } from 'shared/hooks/useTimers'
 
 const dummyUserImage = 'https://tva1.sinaimg.cn/large/e6c9d24egy1h3g25xp63rj20e80e8gm1.jpg'
@@ -55,16 +55,13 @@ export const useUser = () => {
 	}
 
 	const signup = async (userInfo = { email: null, fullName: 'unknown', password: null }) => {
-		const { isSuccess, message, user, ...newLoginData } = await requestSignup(userInfo)
-
+		const { isSuccess, message, user, token, ...newLoginData } = await requestSignup(userInfo)
 		if (!isSuccess) {
 			return { isSuccess, message }
 		}
 
-		setLoginData(newLoginData)
-		setUser({ ...user, image: user.image ?? dummyUserImage })
-		createPost()
-
+		await createPost(token)
+		await login(userInfo)
 		return { isSuccess, message: '회원가입에 성공했습니다.' }
 	}
 


### PR DESCRIPTION
## 개요
회원 가입 후 API 호출 수정

## 작업 내용

1. Recoil 동기화 이슈 c747fc2eb8c33c0f3c5896407d35fec0d3200ed9
- 유저정보를 전역 상태로 관리하며 sessionStorageEffect 를 사용하여 동기화하고 있습니다.
- 회원가입과 동시에 유저 정보를 업데이트해도 특정 시점까지는 session storage에 세팅되지 않는 것을 확인했습니다.
- 해당 이슈로 인해 session 정보 기반으로 axios config를 갱신 할 수 없어 임의처리한 API 호출이 존재합니다.
-> 이 이슈는 이후 리팩토링 과정이 필요합니다


2. 회원가입 성공시 바로 로그인 되도록 훅 내부 메소드를 사용하여 수정해두었습니다. c747fc2eb8c33c0f3c5896407d35fec0d3200ed9

- 회원가입 시 필요한 API 호출 - 회원가입, Post 등록, 로그인
  - 회원가입 -> Post 등록 -> 로그인 
   - 회원가입 성공시 API Reponse 받은 Token 기준으로 Post 등록 API 1회 호출
    - 기본적으로 1인 1포스트만 가능하며, 비회원도 글을 포스팅 할 수 있지만 공유할 수 없습니다.
    - 회원가입 시점에서 postId를 회원과 매핑하여 프리징합니다.
    - 회원가입 즉시 로그인됩니다.

## 이슈

현재 기준으로 api 호출시에 매 페이지 마다 클로저로 인하여 해당 컨텍스트 axios instance를 참고 하고 있습니다.
이후 리팩토리시에는 다음과 같이 모듈단위로 작업하여 config를 커스텀하는 방식으로 진행을 고려해야합니다.
![signup-closure](https://user-images.githubusercontent.com/64780560/174980168-a8249a07-02d0-45db-b2bb-dcbe49038561.png)
![image](https://user-images.githubusercontent.com/64780560/174980805-a2e71df8-fc86-4a73-9a5e-7263ae87a9da.png)


## 참고 자료
[Recoil storage-persistence](https://recoiljs.org/ko/docs/guides/atom-effects/#local-storage-persistence-%EB%A1%9C%EC%BB%AC-%EC%8A%A4%ED%86%A0%EB%A6%AC%EC%A7%80-%EC%A7%80%EC%86%8D%EC%84%B1)